### PR TITLE
컨텐츠 추가에 따른 일기 관련 API 수정

### DIFF
--- a/controllers/diary.controller.js
+++ b/controllers/diary.controller.js
@@ -381,6 +381,7 @@ exports.getTodayInfo = async function (req, res) {
       message: "Failed to get today's result.(getDiaryToday)",
     });
   } else if (getTodayResult == "Success") {
+    console.log("Success");
     return res.status(201).send({
       isSuccess: true,
       code: 201,

--- a/models/diary.model.js
+++ b/models/diary.model.js
@@ -471,7 +471,7 @@ exports.getDiaryToday = async function(providerId){
     const connection = await pool.getConnection(async (conn) => conn);
     console.log(`##### Connection_pool_GET #####`);
     try{
-      const getDiaryWrittenTodayQuery = "select * from diary where providerId = ? and written_date = curdate()"
+      const getDiaryWrittenTodayQuery = "select d.id,d.providerId,d.content,d.emotion,d.contents_id,c.type,c.name,c.publisher,c.url from diary as d left join content as c on d.contents_id = c.id where d.providerId = ? and d.written_date = curdate();"
       let params = providerId
       const [row] = await connection.query(getDiaryWrittenTodayQuery,params);
       if(Array.isArray(row) && row.length === 0){

--- a/models/diary.model.js
+++ b/models/diary.model.js
@@ -474,6 +474,7 @@ exports.getDiaryToday = async function(providerId){
       const getDiaryWrittenTodayQuery = "select d.id,d.providerId,d.content,d.emotion,d.contents_id,c.type,c.name,c.publisher,c.url from diary as d left join content as c on d.contents_id = c.id where d.providerId = ? and d.written_date = curdate();"
       let params = providerId
       const [row] = await connection.query(getDiaryWrittenTodayQuery,params);
+      console.log(row);
       if(Array.isArray(row) && row.length === 0){
         connection.release();
         return "Success";

--- a/sql/test-setting.sql
+++ b/sql/test-setting.sql
@@ -74,18 +74,6 @@ CREATE TABLE feedback_hashtag(
     PRIMARY KEY (id)
 );
 
-CREATE TABLE feedback_hashtag(
-    id INT NOT NULL AUTO_INCREMENT,
-    diary_content VARCHAR(10000) NOT NULL,
-    hashtag1_original VARCHAR(20),
-    hashtag2_original VARCHAR(20),
-    hashtag3_original VARCHAR(20),
-    hashtag1_changed VARCHAR(20),
-    hashtag2_changed VARCHAR(20),
-    hashtag3_changed VARCHAR(20),
-    opinion VARCHAR(2000),
-    PRIMARY KEY (id)
-);
 
 CREATE TABLE content(
     id INT NOT NULL AUTO_INCREMENT,

--- a/sql/test-setting.sql
+++ b/sql/test-setting.sql
@@ -74,15 +74,38 @@ CREATE TABLE feedback_hashtag(
     PRIMARY KEY (id)
 );
 
+CREATE TABLE feedback_hashtag(
+    id INT NOT NULL AUTO_INCREMENT,
+    diary_content VARCHAR(10000) NOT NULL,
+    hashtag1_original VARCHAR(20),
+    hashtag2_original VARCHAR(20),
+    hashtag3_original VARCHAR(20),
+    hashtag1_changed VARCHAR(20),
+    hashtag2_changed VARCHAR(20),
+    hashtag3_changed VARCHAR(20),
+    opinion VARCHAR(2000),
+    PRIMARY KEY (id)
+);
+
+CREATE TABLE content(
+    id INT NOT NULL AUTO_INCREMENT,
+    type varchar(30),
+    emotion varchar(30),
+    name varchar(50),
+    publisher varchar(50),
+    url varchar(300),
+    PRIMARY KEY(id)
+);
+
 insert into user(email,name,provider,providerId,token) values ("asd123@gmail.com","테스트1","google","123124435","qeklnklviqoebbzscklb12312445");
 insert into user(email,name,provider,providerId,token) values ("qwesad123@gmail.com","테스트2","google","435624563","snklfnalknk123ehilg123756i1z");
 insert into user(email,name,provider,providerId,token) values ("bnlik4tn21@gmail.com","테스트3","google","906457842","v2b98by98c189xhiu5ninanklas");
 insert into user(email,name,provider,providerId,token) values ("46nklnszc@gmail.com","테스트4","google","785681234","43btvny981y98cn1noihjnroiqw");
 
-insert into diary(providerId,content,emotion,hashtag_1,hashtag_2,hashtag_3) values ("123124435","그녀의 모습을 목격하는 순간부터 내 가슴은 땅울림처럼 떨리고, 입안은 사막처럼 바싹 말라버린다.","놀람", "여행","스페인","비행기");
-insert into diary(providerId,content,emotion,hashtag_1,hashtag_2,hashtag_3) values ("435624563","내가 지금 기억할 수 있는 것은, 그녀가 그다지 미인이 아니었다는 사실 뿐이다. 왠지 조금 이상하기도 하다.","행복","마스크","빨래","카페");
-insert into diary(providerId,content,emotion,hashtag_1,hashtag_2,hashtag_3) values ("906457842","그녀는 동에서 서로, 나는 서에서 동으로 걷고 있었다. 제법 기분이 좋은 4월의 아침이다.","중립","독서","청소","게임");
-insert into diary(providerId,content,emotion,hashtag_1,hashtag_2,hashtag_3,written_date) values ("906457842","그녀는 동에서 서로, 나는 서에서 동으로 걷고 있었다. 제법 기분이 좋은 4월의 아침이다.","중립","독서","청소","게임","2022-05-15");
+insert into diary(providerId,content,emotion,hashtag_1,hashtag_2,hashtag_3,contents_id) values ("123124435","그녀의 모습을 목격하는 순간부터 내 가슴은 땅울림처럼 떨리고, 입안은 사막처럼 바싹 말라버린다.","놀람", "여행","스페인","비행기","285");
+insert into diary(providerId,content,emotion,hashtag_1,hashtag_2,hashtag_3,contents_id) values ("435624563","내가 지금 기억할 수 있는 것은, 그녀가 그다지 미인이 아니었다는 사실 뿐이다. 왠지 조금 이상하기도 하다.","행복","마스크","빨래","카페","123");
+insert into diary(providerId,content,emotion,hashtag_1,hashtag_2,hashtag_3,contents_id) values ("906457842","그녀는 동에서 서로, 나는 서에서 동으로 걷고 있었다. 제법 기분이 좋은 4월의 아침이다.","중립","독서","청소","게임","3");
+insert into diary(providerId,content,emotion,hashtag_1,hashtag_2,hashtag_3,contents_id,written_date) values ("906457842","그녀는 동에서 서로, 나는 서에서 동으로 걷고 있었다. 제법 기분이 좋은 4월의 아침이다.","중립","독서","청소","게임","57","2022-05-15");
 
 insert into emotion_score(diary_id,happy_score,fear_score,disgust_score,anger_score,neutral_score,surprise_score,sad_score) values (1,22.3,11.5,8.7,5.7,44.8,3.7,3.3);
 insert into emotion_score(diary_id,happy_score,fear_score,disgust_score,anger_score,neutral_score,surprise_score,sad_score) values (2,11.5,8.7,5.7,44.8,3.7,3.3,22.3);

--- a/swagger-output.json
+++ b/swagger-output.json
@@ -1048,12 +1048,11 @@
                     "providerId": "785681234",
                     "content": "그녀의 모습을 목격하는 순간부터 내 가슴은 땅울림처럼 떨리고, 입안은 사막처럼 바싹 말라버린다.",
                     "emotion": "행복",
-                    "contents_id": null,
-                    "counselor_id": null,
-                    "hashtag_1": "강의",
-                    "hashtag_2": "영화",
-                    "hashtag_3": "떡볶이",
-                    "written_date": "2022-05-22"
+                    "contents_id": "384",
+                    "type": "음악",
+                    "name": "Happy Town",
+                    "publisher": "MapleStory OST",
+                    "url": "https://www.youtube.com/watch?v=hbl-i0lhMcI&ab_channel=yeonH"
                   }
                 ],
                 "message": "Today's diary already exists.",

--- a/test/test.diary.js
+++ b/test/test.diary.js
@@ -182,6 +182,16 @@ describe("GET /diaries/today/:providerId", () => {
         if (err) {
           throw err;
         }
+        res.body.should.have.property("getTodayResult");
+        should.exist(res.body.getTodayResult[0].id);
+        should.exist(res.body.getTodayResult[0].providerId);
+        should.exist(res.body.getTodayResult[0].content);
+        should.exist(res.body.getTodayResult[0].emotion);
+        should.exist(res.body.getTodayResult[0].contents_id);
+        should.exist(res.body.getTodayResult[0].type);
+        should.exist(res.body.getTodayResult[0].name);
+        should.exist(res.body.getTodayResult[0].publisher);
+        should.exist(res.body.getTodayResult[0].url);
         res.body.code.should.be.equal(200);
         res.body.isSuccess.should.be.equal(true);
         res.body.message.should.be.equal("Today's diary already exists.");


### PR DESCRIPTION
## 제목
컨텐츠 추가에 따른 일기 관련 API 수정

## 작업 내용
일기 작성, 수정, 감정 수정 시 컨텐츠 추천 정보 업데이트 기능 추가

## 설명 ( 필요 시 )
일기 작성시 -> 작성된 일기의 감정 리턴값에 해당하는 컨텐츠 중 하나 추천,
일기 수정 시 -> 수정된 일기의 감정 리턴값에 해당하는 컨텐츠 중 하나 추천,
일기 감정 수정 시 -> 감정 수정 정보에 따라 해당 감정에 해당하는 컨텐츠 중 하나 추천

## 테스트 여부 / 테스트 방법
Mocha, Supertest를 통한 유닛 테스트 완료

