### PR TITLE
사용자 Id별 감정 통계 정보 제공하는 API 추가

### DIFF
--- a/controllers/diary.controller.js
+++ b/controllers/diary.controller.js
@@ -396,3 +396,36 @@ exports.getTodayInfo = async function (req, res) {
     code: 200,
   });
 };
+
+
+exports.fetchEmotionCount = async function(req,res){
+  const providerIdCheck = await Diary.providerIdCheck(req.params.providerId);
+  if (!providerIdCheck) {
+    return res.status(500).send({
+      isSuccess: false,
+      code: 500,
+      message: "Failed to get today's diary info.(providerIdCheck)",
+    });
+  } else if (providerIdCheck == "idCheck") {
+    return res.status(404).send({
+      isSuccess: false,
+      code: 404,
+      message: "Check id value.",
+    });
+  }
+
+  const emotionCountResult = await Diary.getEmotionCount(req.params.providerId);
+  if(!emotionCountResult){
+    return res.status(500).send({
+      isSuccess: false,
+      code: 500,
+      message: "Failed to get emotion count.(getEmotionCount)",
+    });
+  }
+  return res.status(200).send({
+    emotionCountResult,
+    isSuccess: true,
+    code: 200,
+  });
+
+}

--- a/models/diary.model.js
+++ b/models/diary.model.js
@@ -1,6 +1,5 @@
 const { pool } = require("./db.js");
 const axios = require("axios");
-const { response } = require("../index.js");
 
 function sleep(ms) {
   const wakeUpTime = Date.now() + ms;

--- a/models/diary.model.js
+++ b/models/diary.model.js
@@ -472,9 +472,8 @@ exports.getDiaryToday = async function(providerId){
     console.log(`##### Connection_pool_GET #####`);
     try{
       const getDiaryWrittenTodayQuery = "select d.id,d.providerId,d.content,d.emotion,d.contents_id,c.type,c.name,c.publisher,c.url from diary as d left join content as c on d.contents_id = c.id where d.providerId = ? and d.written_date = curdate();"
-      let params = providerId
+      let params = providerId;
       const [row] = await connection.query(getDiaryWrittenTodayQuery,params);
-      console.log(row);
       if(Array.isArray(row) && row.length === 0){
         connection.release();
         return "Success";
@@ -483,6 +482,44 @@ exports.getDiaryToday = async function(providerId){
         connection.release();
         return row;
       }
+    }catch(err){
+      console.error(`##### Query error ##### `);
+      connection.release();
+      return false;
+    }
+  }catch(err){
+    console.error(`##### DB error #####`);
+    return false;
+  }
+}
+
+exports.getEmotionCount = async function(providerId){
+  try{
+    const connection = await pool.getConnection(async (conn) => conn);
+    console.log(`##### Connection_pool_GET #####`);
+    try{
+      const getEmotionCountQuery = "SELECT e.emotion, IFNULL(d.CNT, 0) AS 'count' FROM emotion AS e LEFT OUTER JOIN ( SELECT emotion, COUNT(*) AS CNT FROM diary where providerId = ? GROUP BY emotion ) AS d ON e.emotion = d.emotion ORDER BY e.emotion";
+      let params = providerId;
+      const [row] = await connection.query(getEmotionCountQuery,params);
+      let fearCount =  await row[0].count;
+      let surpriseCount = await row[1].count;
+      let angryCount = await row[2].count;
+      let sadCount = await row[3].count;
+      let neutralCount = await row[4].count;
+      let happyCount = await row[5].count;
+      let disgustCount = await row[6].count;
+      let countResult = [];
+      countResult.push({
+        "공포" : fearCount,
+        "놀람" : surpriseCount,
+        "분노" : angryCount,
+        "슬픔" : sadCount,
+        "중립" : neutralCount,
+        "행복" : happyCount,
+        "혐오" : disgustCount
+      })
+      connection.release();
+      return countResult;
     }catch(err){
       console.error(`##### Query error ##### `);
       connection.release();

--- a/routes/diary.routes.js
+++ b/routes/diary.routes.js
@@ -11,4 +11,5 @@ module.exports = app =>{
     app.get("/diaries/today/:providerId", diary.getTodayInfo);
     app.patch("/diaries/emotions/:id",diary.updateEmotion);
     app.patch("/diaries/hashtags/:id",diary.updateHashtag);
+    app.get("/diaries/emotioncounts/:providerId",diary.fetchEmotionCount);
 };

--- a/sql/test-setting.sql
+++ b/sql/test-setting.sql
@@ -37,6 +37,10 @@ CREATE TABLE diary (
     REFERENCES user (providerId) on delete cascade
 );
 
+CREATE TABLE emotion(
+    emotion varchar(20)
+);
+
 CREATE TABLE emotion_score(
     id INT NOT NULL AUTO_INCREMENT,
     diary_id INT NOT NULL,
@@ -84,6 +88,14 @@ CREATE TABLE content(
     url varchar(300),
     PRIMARY KEY(id)
 );
+
+insert into emotion(emotion) values ("행복");
+insert into emotion(emotion) values ("중립");
+insert into emotion(emotion) values ("공포");
+insert into emotion(emotion) values ("혐오");
+insert into emotion(emotion) values ("분노");
+insert into emotion(emotion) values ("놀람");
+insert into emotion(emotion) values ("슬픔");
 
 insert into user(email,name,provider,providerId,token) values ("asd123@gmail.com","테스트1","google","123124435","qeklnklviqoebbzscklb12312445");
 insert into user(email,name,provider,providerId,token) values ("qwesad123@gmail.com","테스트2","google","435624563","snklfnalknk123ehilg123756i1z");

--- a/swagger-output.json
+++ b/swagger-output.json
@@ -1094,6 +1094,56 @@
         }
       }
     },
+    "/diaries/emotioncounts/:providerId":{
+      "get" : {
+        "tags" : ["Diary"],
+        "summary" : "사용자별 감정별 일기 개수 Count - Frontend",
+        "description" : "해당 providerId가 작성한 전체 일기 중 어떤 감정에 몇개가 해당하는지에 대한 정보를 리턴합니다.",
+        "parameters": [
+          {
+            "name": "providerId",
+            "description": "통계 정보를 얻고 싶은 providerId Value",
+            "in": "path",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses":{
+          "200": {
+            "description": "OK (통계 정보가 성공적으로 리턴됨)" ,
+            "schema": {
+              "example": {
+                "emotionCountResult": [
+                  { "공포": 1, "놀람": 4, "분노": 2, "슬픔": 3, "중립": 3, "행복": 6, "혐오": 0 }
+                ],
+                "isSuccess": true,
+                "code": 200
+              }
+            }
+          },
+          "404": {
+            "description": "Not Found (존재하지 않는 providerId에 대한 조회 요청)",
+            "schema": {
+              "example": {
+                "isSuccess": false,
+                "code": 404,
+                "message": "Check id value."
+              }
+            }
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "schema": {
+              "example": {
+                "isSuccess": false,
+                "code": 500,
+                "message": "Failed to get emotion count.(getEmotionCount)"
+              }
+            }
+          }
+        }
+      }
+    },
     "/feedbacks/emotions":{
       "post": {
         "tags": ["Feedback"],

--- a/test/test.diary.js
+++ b/test/test.diary.js
@@ -201,6 +201,40 @@ describe("GET /diaries/today/:providerId", () => {
   });
 });
 
+describe("GET /diaries/emotioncounts/:providerId", () => {
+  it("emotioncounts 실패 Test (존재하지 않는 providerId에 대한 요청)", (done) => {
+    request(app)
+      .get("/diaries/emotioncounts/5346872398047")
+      .end((err, res) => {
+        if (err) {
+          throw err;
+        }
+        res.body.code.should.be.equal(404);
+        res.body.isSuccess.should.be.equal(false);
+        res.body.message.should.be.equal("Check id value.");
+        console.log(res.body);
+        done();
+      });
+  });
+});
+
+describe("GET /diaries/emotioncounts/:providerId", () => {
+  it("emotioncounts 성공 Test ", (done) => {
+    request(app)
+      .get("/diaries/emotioncounts/785681234")
+      .end((err, res) => {
+        if (err) {
+          throw err;
+        }
+        res.body.should.have.property("emotionCountResult");
+        res.body.code.should.be.equal(200);
+        res.body.isSuccess.should.be.equal(true);
+        console.log(res.body);
+        done();
+      });
+  });
+});
+
 describe("POST /diaries/:providerId", () => {
   it("일기 중복 작성 Test", (done) => {
     request(app)

--- a/test/test.user.js
+++ b/test/test.user.js
@@ -113,6 +113,7 @@ describe("PATCH /users", () => {
   });
 });
 
+
 describe("PATCH /users", () => {
   it("특정 유저의 정보를 수정하는 Test.", (done) => {
     request(app)


### PR DESCRIPTION
## 제목
사용자 Id별 감정 통계 정보 제공하는 API 추가

## 작업 내용
diary API 에서 /diaries/emotioncounts/:providerID에 해당하는 API 구현

## 설명 ( 필요 시 )
사용자 providerId별 전체 일기 목록에서 어떤 감정에 해당하는 일기가 몇개가 있는지 리턴하는 API 구현

## 테스트 여부 / 테스트 방법
Mocha와 Supertest를 통한 테스트 완료

