### PR TITLE
사용자 Id별 감정에 따른 일기 목록 제공하는 API 추가

### DIFF
--- a/controllers/diary.controller.js
+++ b/controllers/diary.controller.js
@@ -266,6 +266,7 @@ exports.searchDiary = async function (req, res) {
   });
 };
 
+// 일기 감정 수정
 exports.updateEmotion = async function (req, res) {
   if (isEmpty(req.body.emotion)) {
     return res.status(400).send({
@@ -309,6 +310,7 @@ exports.updateEmotion = async function (req, res) {
   });
 };
 
+// 일기 해시태그 수정
 exports.updateHashtag = async function (req, res) {
   if (
     isEmpty(req.body.hashtag_1) ||
@@ -357,6 +359,7 @@ exports.updateHashtag = async function (req, res) {
   });
 };
 
+// 오늘 작성한 일기 존재여부
 exports.getTodayInfo = async function (req, res) {
   const providerIdCheck = await Diary.providerIdCheck(req.params.providerId);
   if (!providerIdCheck) {
@@ -397,8 +400,8 @@ exports.getTodayInfo = async function (req, res) {
   });
 };
 
-
-exports.fetchEmotionCount = async function(req,res){
+// 특정 사용자의 감정별 일기 개수
+exports.fetchEmotionCount = async function (req, res) {
   const providerIdCheck = await Diary.providerIdCheck(req.params.providerId);
   if (!providerIdCheck) {
     return res.status(500).send({
@@ -415,7 +418,7 @@ exports.fetchEmotionCount = async function(req,res){
   }
 
   const emotionCountResult = await Diary.getEmotionCount(req.params.providerId);
-  if(!emotionCountResult){
+  if (!emotionCountResult) {
     return res.status(500).send({
       isSuccess: false,
       code: 500,
@@ -427,5 +430,53 @@ exports.fetchEmotionCount = async function(req,res){
     isSuccess: true,
     code: 200,
   });
+};
 
-}
+// 특정 사용자의 감정별 일기 목록
+exports.getDiaryByEmotion = async function (req, res) {
+  const providerIdCheck = await Diary.providerIdCheck(req.params.providerId);
+  if (!providerIdCheck) {
+    return res.status(500).send({
+      isSuccess: false,
+      code: 500,
+      message: "Failed to get diary by emotion.(providerIdCheck)",
+    });
+  } else if (providerIdCheck == "idCheck") {
+    return res.status(404).send({
+      isSuccess: false,
+      code: 404,
+      message: "Check id value.",
+    });
+  }
+  let checkEmotion = 0;
+  let arr = ["공포", "행복", "중립", "혐오", "슬픔", "분노", "놀람"];
+  arr.forEach((emotion) => {
+    if (req.body.emotion == emotion) {
+      checkEmotion = 1;
+    }
+  });
+  if (!checkEmotion) {
+    return res.status(400).send({
+      isSuccess: false,
+      code: 400,
+      message: "Check Emotion Input.",
+    });
+  }
+
+  const getDiaryResult = await Diary.getDiaryByEmotion(
+    req.body.emotion,
+    req.params.providerId
+  );
+  if (!getDiaryResult) {
+    return res.status(500).send({
+      isSuccess: false,
+      code: 500,
+      message: "Failed to get diary by emotion.(getDiaryByEmotion)",
+    });
+  }
+  return res.status(200).send({
+    getDiaryResult,
+    isSuccess: true,
+    code: 200,
+  });
+};

--- a/controllers/feedback.controller.js
+++ b/controllers/feedback.controller.js
@@ -5,7 +5,7 @@ function isEmpty(str) {
   else return false;
 }
 
-
+// 전체 감정 피드백
 exports.getAllEmotionFeedback = async function (req, res) {
   const emotionFeedbackResult = await feedback.getEmotionFeedbackInfo();
   if (!emotionFeedbackResult) {
@@ -34,6 +34,7 @@ exports.getAllEmotionFeedback = async function (req, res) {
   });
 };
 
+// 전체 해시태그 피드백
 exports.getAllHashtagFeedback = async function (req, res) {
   const hashtagFeedbackResult = await feedback.getHashtagFeedbackInfo();
   if (!hashtagFeedbackResult) {
@@ -62,6 +63,7 @@ exports.getAllHashtagFeedback = async function (req, res) {
   });
 };
 
+// 감정 피드백 등록
 exports.postEmotionFeedback = async function (req, res) {
   if (
     isEmpty(req.body.diary_content) ||
@@ -94,6 +96,7 @@ exports.postEmotionFeedback = async function (req, res) {
   });
 };
 
+// 해시태그 피드백 등록
 exports.postHashtagFeedback = async function (req, res) {
   if (
     isEmpty(req.body.diary_content) ||

--- a/controllers/user.controller.js
+++ b/controllers/user.controller.js
@@ -1,4 +1,3 @@
-
 const User = require("../models/user.model.js");
 
 function isEmpty(str) {

--- a/models/diary.model.js
+++ b/models/diary.model.js
@@ -127,18 +127,20 @@ exports.diaryWrite = async function (providerId, content) {
       });*/
       test();
       try {
-        const getEmotionCountQuery = "SELECT count(*) as count FROM content WHERE emotion = ?";
+        const getEmotionCountQuery =
+          "SELECT count(*) as count FROM content WHERE emotion = ?";
         //let params = response.data.emotion;
         let params = dummy_emotion;
-        let [row] = await connection.query(getEmotionCountQuery,params);
+        let [row] = await connection.query(getEmotionCountQuery, params);
         let count = row[0].count;
-        let randNum = rand(1,count) - 1;
-        const getContentQuery = "SELECT * FROM content WHERE emotion = ? limit ?,1";
+        let randNum = rand(1, count) - 1;
+        const getContentQuery =
+          "SELECT * FROM content WHERE emotion = ? limit ?,1";
         params = [dummy_emotion, randNum];
         //params = [response.data.emotion, randNum];
-        [row] = await connection.query(getContentQuery,params);
+        [row] = await connection.query(getContentQuery, params);
         let contentNumber = row[0].id;
-        
+
         const writeDiaryQuery =
           "INSERT INTO diary(providerId,content,emotion,hashtag_1,hashtag_2,hashtag_3,contents_id) values (?,?,?,?,?,?,?)";
         /* 실제 코드
@@ -159,7 +161,7 @@ exports.diaryWrite = async function (providerId, content) {
           dummy_hashtag_1,
           dummy_hashtag_2,
           dummy_hashtag_3,
-          contentNumber
+          contentNumber,
         ];
         [row] = await connection.query(writeDiaryQuery, params);
         let insertId = row.insertId;
@@ -210,16 +212,18 @@ exports.diaryUpdate = async function (Id, content) {
       });*/
       test();
       try {
-        const getEmotionCountQuery = "SELECT count(*) as count FROM content WHERE emotion = ?";
+        const getEmotionCountQuery =
+          "SELECT count(*) as count FROM content WHERE emotion = ?";
         //let params = response.data.emotion;
         let params = dummy_emotion;
-        let [row] = await connection.query(getEmotionCountQuery,params);
+        let [row] = await connection.query(getEmotionCountQuery, params);
         let count = row[0].count;
-        let randNum = rand(1,count) - 1;
-        const getContentQuery = "SELECT * FROM content WHERE emotion = ? limit ?,1";
+        let randNum = rand(1, count) - 1;
+        const getContentQuery =
+          "SELECT * FROM content WHERE emotion = ? limit ?,1";
         params = [dummy_emotion, randNum];
         //params = [response.data.emotion, randNum];
-        [row] = await connection.query(getContentQuery,params);
+        [row] = await connection.query(getContentQuery, params);
         let contentNumber = row[0].id;
 
         const updateDiaryQuery =
@@ -409,19 +413,22 @@ exports.diaryEmotionUpdate = async function (id, emotion) {
     const connection = await pool.getConnection(async (conn) => conn);
     console.log(`##### Connection_pool_GET #####`);
     try {
-      const getEmotionCountQuery = "SELECT count(*) as count FROM content WHERE emotion = ?";
+      const getEmotionCountQuery =
+        "SELECT count(*) as count FROM content WHERE emotion = ?";
       //let params = response.data.emotion;
       let params = emotion;
-      let [row] = await connection.query(getEmotionCountQuery,params);
+      let [row] = await connection.query(getEmotionCountQuery, params);
       let count = row[0].count;
-      let randNum = rand(1,count) - 1;
-      const getContentQuery = "SELECT * FROM content WHERE emotion = ? limit ?,1";
+      let randNum = rand(1, count) - 1;
+      const getContentQuery =
+        "SELECT * FROM content WHERE emotion = ? limit ?,1";
       params = [dummy_emotion, randNum];
       //params = [response.data.emotion, randNum];
-      [row] = await connection.query(getContentQuery,params);
+      [row] = await connection.query(getContentQuery, params);
       let contentNumber = row[0].id;
 
-      const updateEmotionDiaryQuery = "update diary set emotion=?, contents_id = ? where id = ?";
+      const updateEmotionDiaryQuery =
+        "update diary set emotion=?, contents_id = ? where id = ?";
       params = [emotion, contentNumber, id];
       await connection.query(updateEmotionDiaryQuery, params);
       connection.release();
@@ -465,42 +472,45 @@ exports.diaryHashtagUpdate = async function (
   }
 };
 
-exports.getDiaryToday = async function(providerId){
+// 오늘 작성된 일기 존재여부
+exports.getDiaryToday = async function (providerId) {
   try {
     const connection = await pool.getConnection(async (conn) => conn);
     console.log(`##### Connection_pool_GET #####`);
-    try{
-      const getDiaryWrittenTodayQuery = "select d.id,d.providerId,d.content,d.emotion,d.contents_id,c.type,c.name,c.publisher,c.url from diary as d left join content as c on d.contents_id = c.id where d.providerId = ? and d.written_date = curdate();"
+    try {
+      const getDiaryWrittenTodayQuery =
+        "select d.id,d.providerId,d.content,d.emotion,d.contents_id,c.type,c.name,c.publisher,c.url from diary as d left join content as c on d.contents_id = c.id where d.providerId = ? and d.written_date = curdate();";
       let params = providerId;
-      const [row] = await connection.query(getDiaryWrittenTodayQuery,params);
-      if(Array.isArray(row) && row.length === 0){
+      const [row] = await connection.query(getDiaryWrittenTodayQuery, params);
+      if (Array.isArray(row) && row.length === 0) {
         connection.release();
         return "Success";
-      }
-      else{
+      } else {
         connection.release();
         return row;
       }
-    }catch(err){
+    } catch (err) {
       console.error(`##### Query error ##### `);
       connection.release();
       return false;
     }
-  }catch(err){
+  } catch (err) {
     console.error(`##### DB error #####`);
     return false;
   }
-}
+};
 
-exports.getEmotionCount = async function(providerId){
-  try{
+// 특정 사용자의 감정별 일기 개수
+exports.getEmotionCount = async function (providerId) {
+  try {
     const connection = await pool.getConnection(async (conn) => conn);
     console.log(`##### Connection_pool_GET #####`);
-    try{
-      const getEmotionCountQuery = "SELECT e.emotion, IFNULL(d.CNT, 0) AS 'count' FROM emotion AS e LEFT OUTER JOIN ( SELECT emotion, COUNT(*) AS CNT FROM diary where providerId = ? GROUP BY emotion ) AS d ON e.emotion = d.emotion ORDER BY e.emotion";
+    try {
+      const getEmotionCountQuery =
+        "SELECT e.emotion, IFNULL(d.CNT, 0) AS 'count' FROM emotion AS e LEFT OUTER JOIN ( SELECT emotion, COUNT(*) AS CNT FROM diary where providerId = ? GROUP BY emotion ) AS d ON e.emotion = d.emotion ORDER BY e.emotion";
       let params = providerId;
-      const [row] = await connection.query(getEmotionCountQuery,params);
-      let fearCount =  await row[0].count;
+      const [row] = await connection.query(getEmotionCountQuery, params);
+      let fearCount = await row[0].count;
       let surpriseCount = await row[1].count;
       let angryCount = await row[2].count;
       let sadCount = await row[3].count;
@@ -509,23 +519,46 @@ exports.getEmotionCount = async function(providerId){
       let disgustCount = await row[6].count;
       let countResult = [];
       countResult.push({
-        "공포" : fearCount,
-        "놀람" : surpriseCount,
-        "분노" : angryCount,
-        "슬픔" : sadCount,
-        "중립" : neutralCount,
-        "행복" : happyCount,
-        "혐오" : disgustCount
-      })
+        공포: fearCount,
+        놀람: surpriseCount,
+        분노: angryCount,
+        슬픔: sadCount,
+        중립: neutralCount,
+        행복: happyCount,
+        혐오: disgustCount,
+      });
       connection.release();
       return countResult;
-    }catch(err){
+    } catch (err) {
       console.error(`##### Query error ##### `);
       connection.release();
       return false;
     }
-  }catch(err){
+  } catch (err) {
     console.error(`##### DB error #####`);
     return false;
   }
-}
+};
+
+// 특정 사용자의 감정에 따른 일기 목록
+exports.getDiaryByEmotion = async function (emotion, providerId) {
+  try {
+    const connection = await pool.getConnection(async (conn) => conn);
+    console.log(`##### Connection_pool_GET #####`);
+    try {
+      const getDiaryByEmotionQuery =
+        "SELECT * from diary where providerId = ? and emotion = ?";
+      let params = [providerId, emotion];
+      const [row] = await connection.query(getDiaryByEmotionQuery, params);
+      connection.release();
+      return row;
+    } catch (err) {
+      console.error(`##### Query error ##### `);
+      connection.release();
+      return false;
+    }
+  } catch (err) {
+    console.error(`##### DB error #####`);
+    return false;
+  }
+};

--- a/models/diary.model.js
+++ b/models/diary.model.js
@@ -547,7 +547,7 @@ exports.getDiaryByEmotion = async function (emotion, providerId) {
     console.log(`##### Connection_pool_GET #####`);
     try {
       const getDiaryByEmotionQuery =
-        "SELECT * from diary where providerId = ? and emotion = ?";
+        "SELECT id,providerId,content,emotion,hashtag_1,hashtag_2,hashtag_3,written_date from diary where providerId = ? and emotion = ?";
       let params = [providerId, emotion];
       const [row] = await connection.query(getDiaryByEmotionQuery, params);
       connection.release();

--- a/models/feedback.model.js
+++ b/models/feedback.model.js
@@ -1,5 +1,6 @@
 const { pool } = require("./db.js");
 
+// 전체 감정 피드백
 exports.getEmotionFeedbackInfo = async function () {
   try {
     const connection = await pool.getConnection(async (conn) => conn);
@@ -22,6 +23,7 @@ exports.getEmotionFeedbackInfo = async function () {
   }
 };
 
+// 전체 해시태그 피드백
 exports.getHashtagFeedbackInfo = async function () {
   try {
     const connection = await pool.getConnection(async (conn) => conn);
@@ -44,6 +46,7 @@ exports.getHashtagFeedbackInfo = async function () {
   }
 };
 
+// 감정 피드백 등록
 exports.postEmotionFeedback = async function (
   content,
   emotion_original,
@@ -73,6 +76,7 @@ exports.postEmotionFeedback = async function (
   }
 };
 
+// 해시태그 피드백 등록
 exports.postHashtagFeedback = async function (
   content,
   hashtag1_original,

--- a/routes/admin.routes.js
+++ b/routes/admin.routes.js
@@ -1,99 +1,101 @@
-const axios = require('axios');
+const axios = require("axios");
 
-module.exports = app =>{
+module.exports = (app) => {
+  app.get("/admin", (req, res) => {
+    res.render("manage");
+  });
 
-    app.get("/admin", (req, res) => {
-        res.render('manage');
-    });
+  app.get("/admin/diaries", (req, res) => {
+    axios
+      .get("http://localhost:3000/diaries")
+      .then((response) => {
+        res.render("diaryList", {
+          title: "Diary List",
+          diaries: response.data.getAllResult,
+        });
+      })
+      .catch((error) => {
+        console.log("error: ", error);
+      });
+  });
 
-    app.get("/admin/diaries", (req, res) => {
-        axios.get("http://localhost:3000/diaries")
-            .then(response => {
-                res.render('diaryList', {
-                    title: 'Diary List',
-                    diaries: response.data.getAllResult
-                })
-            })
-            .catch(error => {
-                console.log('error: ', error);
-            })
-    });
+  app.get("/admin/diaries/details/:id", (req, res) => {
+    axios
+      .delete(`http://localhost:3000/diaries/details/${req.params.id}`)
+      .then((response) => {
+        console.log(response.data.deleteResult);
+        res.redirect("/admin/diaries");
+      })
+      .catch((error) => {
+        console.log("error: ", error);
+      });
+  });
 
-    app.get("/admin/diaries/details/:id", (req, res) => {
-        axios.delete(`http://localhost:3000/diaries/details/${req.params.id}`)
-            .then(response => {
-                console.log(response.data.deleteResult);
-                res.redirect('/admin/diaries');
-            })
-            .catch(error => {
-                console.log('error: ', error);
-            })
-    });
+  app.get("/admin/users", (req, res) => {
+    axios
+      .get("http://localhost:3000/users")
+      .then((response) => {
+        res.render("userList", {
+          title: "User List",
+          users: response.data.userInfo,
+        });
+      })
+      .catch((error) => {
+        console.log("error: ", error);
+      });
+  });
 
-    app.get("/admin/users", (req, res) => {
-        axios.get("http://localhost:3000/users")
-            .then(response => {
-                res.render('userList', {
-                    title: 'User List',
-                    users: response.data.userInfo
-                })
-            })
-            .catch(error => {
-                console.log('error: ', error);
-            })
-    });
+  app.get("/admin/users/details/:providerId", (req, res) => {
+    axios
+      .delete(`http://localhost:3000/users/${req.params.providerId}`)
+      .then((response) => {
+        console.log(response.data.deleteResult);
+        res.redirect("/admin/users");
+      })
+      .catch((error) => {
+        console.log("error: ", error);
+      });
+  });
 
-    app.get("/admin/users/details/:providerId", (req, res) => {
-        axios.delete(`http://localhost:3000/users/${req.params.providerId}`)
-            .then(response => {
-                console.log(response.data.deleteResult);
-                res.redirect('/admin/users');
-            })
-            .catch(error => {
-                console.log('error: ', error);
-            })
-    });
+  app.get("/admin/feedbacks/emotions", (req, res) => {
+    axios
+      .get("http://localhost:3000/feedbacks/emotions")
+      .then((response) => {
+        if (response.data.emotionFeedbackResult.length === 0) {
+          return res.status(404).send({
+            isSuccess: false,
+            code: 404,
+            message: "There is no emotion feedback.",
+          });
+        }
+        res.render("feedbackEmotionList", {
+          title: "Emotion Feedback List",
+          feedbackEmotion: response.data.emotionFeedbackResult,
+        });
+      })
+      .catch((error) => {
+        console.log("error: ", error);
+      });
+  });
 
-    app.get("/admin/feedbacks/emotions", (req, res) => {
-        axios.get("http://localhost:3000/feedbacks/emotions")
-            .then(response => {
-                if(response.data.emotionFeedbackResult.length === 0){
-                    return res.status(404).send({
-                        isSuccess : false,
-                        code : 404,
-                        message : "There is no emotion feedback."
-                      });
-                }
-                res.render('feedbackEmotionList', {
-                    title: 'Emotion Feedback List',
-                    feedbackEmotion: response.data.emotionFeedbackResult
-                })
-            })
-            .catch(error => {
-                console.log('error: ', error);
-            })
-    }
-    );
-
-    app.get("/admin/feedbacks/hashtags", (req, res) => {
-        axios.get("http://localhost:3000/feedbacks/hashtags")
-            .then(response => {
-                if(response.data.hashtagFeedbackResult.length === 0){
-                    return res.status(404).send({
-                        isSuccess : false,
-                        code : 404,
-                        message : "There is no hashtag feedback."
-                      });
-                }
-                res.render('feedbackHashtagList', {
-                    title: 'Hashtag Feedback List',
-                    feedbackHashtag: response.data.hashtagFeedbackResult
-                })
-            })
-            .catch(error => {
-                console.log('error: ', error);
-            })
-    }
-    );
-
+  app.get("/admin/feedbacks/hashtags", (req, res) => {
+    axios
+      .get("http://localhost:3000/feedbacks/hashtags")
+      .then((response) => {
+        if (response.data.hashtagFeedbackResult.length === 0) {
+          return res.status(404).send({
+            isSuccess: false,
+            code: 404,
+            message: "There is no hashtag feedback.",
+          });
+        }
+        res.render("feedbackHashtagList", {
+          title: "Hashtag Feedback List",
+          feedbackHashtag: response.data.hashtagFeedbackResult,
+        });
+      })
+      .catch((error) => {
+        console.log("error: ", error);
+      });
+  });
 };

--- a/routes/diary.routes.js
+++ b/routes/diary.routes.js
@@ -1,15 +1,28 @@
-module.exports = app =>{
-    const diary = require("../controllers/diary.controller.js");
+module.exports = (app) => {
+  const diary = require("../controllers/diary.controller.js");
 
-    app.get("/diaries",diary.findAll);
-    app.post("/diaries/:providerId",diary.writeDiary);
-    app.get("/diaries/:providerId",diary.fetchDiaryByProviderId);
-    app.delete("/diaries/details/:id",diary.deleteDiary);
-    app.get("/diaries/details/:id", diary.fetchDiaryDetailById);
-    app.patch("/diaries/details/:id",diary.updateDiary);
-    app.post("/diaries/searchresults/:providerId",diary.searchDiary);
-    app.get("/diaries/today/:providerId", diary.getTodayInfo);
-    app.patch("/diaries/emotions/:id",diary.updateEmotion);
-    app.patch("/diaries/hashtags/:id",diary.updateHashtag);
-    app.get("/diaries/emotioncounts/:providerId",diary.fetchEmotionCount);
+  // 전체 일기 목록
+  app.get("/diaries", diary.findAll);
+  // 일기 작성
+  app.post("/diaries/:providerId", diary.writeDiary);
+  // 사용자별 일기 목록
+  app.get("/diaries/:providerId", diary.fetchDiaryByProviderId);
+  // 일기 삭제
+  app.delete("/diaries/details/:id", diary.deleteDiary);
+  // 해당 일기의 세부 정보
+  app.get("/diaries/details/:id", diary.fetchDiaryDetailById);
+  // 일기 내용 수정
+  app.patch("/diaries/details/:id", diary.updateDiary);
+  // 일기 검색
+  app.post("/diaries/searchresults/:providerId", diary.searchDiary);
+  // 오늘 작성된 일기 여부
+  app.get("/diaries/today/:providerId", diary.getTodayInfo);
+  // 일기 감정 수정
+  app.patch("/diaries/emotions/:id", diary.updateEmotion);
+  // 일기 해시태그 수정
+  app.patch("/diaries/hashtags/:id", diary.updateHashtag);
+  // 특정 사용자의 감정별 일기 개수
+  app.get("/diaries/emotioncounts/:providerId", diary.fetchEmotionCount);
+  //특정 사용자의 감정별 일기 목록
+  app.post("/diaries/emotions/:providerId", diary.getDiaryByEmotion);
 };

--- a/routes/feedback.routes.js
+++ b/routes/feedback.routes.js
@@ -1,8 +1,12 @@
 module.exports = (app) => {
   const feedback = require("../controllers/feedback.controller.js");
 
+  // 전체 감정 피드백
   app.get("/feedbacks/emotions", feedback.getAllEmotionFeedback);
+  // 전체 해시태그 피드백
   app.get("/feedbacks/hashtags", feedback.getAllHashtagFeedback);
+  // 감정 피드백 등록
   app.post("/feedbacks/emotions", feedback.postEmotionFeedback);
+  // 해시태그 피드백 등록
   app.post("/feedbacks/hashtags", feedback.postHashtagFeedback);
 };

--- a/routes/google.routes.js
+++ b/routes/google.routes.js
@@ -12,20 +12,20 @@ module.exports = (app) => {
   // google login 성공과 실패 리다이렉트 라우트 지정
   app.get(
     "/auth/google/callback",
-      passport.authenticate("google", {
-        failureRedirect: "/auth/google/fail", session : true
-      }),
-      function(req,res){
-        console.log(req.query);
-        return res.redirect("http://localhost:3000");
-      }
+    passport.authenticate("google", {
+      failureRedirect: "/auth/google/fail",
+      session: true,
+    }),
+    function (req, res) {
+      console.log(req.query);
+      return res.redirect("http://localhost:3000/main");
+    }
   );
 
   // login 실패 시 로그인창으로 다시 redirect
-  app.get("/auth/google/fail",(req,res) => {
+  app.get("/auth/google/fail", (req, res) => {
     res.redirect("/auth/google");
   });
-
 
   // logout
   app.get("/logout", (req, res) => {
@@ -33,17 +33,16 @@ module.exports = (app) => {
     return res.redirect("http://localhost:3000");
   });
 
-  // login check 
-  app.get("/checklogin", (req,res) => {
-    if(!req.user){
+  // login check
+  app.get("/checklogin", (req, res) => {
+    if (!req.user) {
       res.status(400).send({
-        isSuccess : false,
-        code : 400,
-        message : "Login Required."
-      })
-    }
-    else{
+        isSuccess: false,
+        code: 400,
+        message: "Login Required.",
+      });
+    } else {
       res.json(req.user);
     }
-  })
+  });
 };

--- a/routes/user.routes.js
+++ b/routes/user.routes.js
@@ -1,8 +1,12 @@
 module.exports = (app) => {
   const users = require("../controllers/user.controller.js");
 
+  // 전체 사용자 목록
   app.get("/users", users.findAll);
+  // 특정 사용자 정보
   app.get("/users/:providerId", users.getUserInfo);
+  // 사용자 삭제
   app.delete("/users/:providerId", users.deleteUser);
+  // 사용자 정보 수정
   app.patch("/users/:providerId", users.updateUserInfo);
 };

--- a/swagger-output.json
+++ b/swagger-output.json
@@ -947,6 +947,97 @@
         }
       }
     },
+    "/diaries/emotions/{providerId}":{
+      "post" : {
+        "tags" : ["Diary"],
+        "summary" : "사용자의 감정별 일기 목록 - Frontend",
+        "description": "감정을 입력해 특정 사용자의 전체 일기 중 해당 감정에 해당하는 일기 목록을 받아오는 API입니다.",
+        "parameters" : [
+          {
+            "name": "providerId",
+            "description": "일기 목록을 받아올 유저의 providerId Value",
+            "in": "path",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "emotion",
+            "in": "body",
+            "schema": {
+              "type": "object",
+              "properties": {
+                "emotion": {
+                  "example": "String"
+                }
+              }
+            }
+          }
+        ],
+        "responses":{
+          "200": {
+            "description": "OK (사용자의 감정별 일기목록을 성공적으로 받아옴)",
+            "schema": {
+              "example": {
+                "getDiaryResult": [
+                  {
+                    "id": 3,
+                    "providerId": "906457842",
+                    "content": "그녀는 동에서 서로, 나는 서에서 동으로 걷고 있었다. 제법 기분이 좋은 4월의 아침이다.",
+                    "emotion": "중립",
+                    "hashtag_1": "독서",
+                    "hashtag_2": "청소",
+                    "hashtag_3": "게임",
+                    "written_date": "2022-05-24"
+                  },
+                  {
+                    "id": 4,
+                    "providerId": "906457842",
+                    "content": "그녀는 동에서 서로, 나는 서에서 동으로 걷고 있었다. 제법 기분이 좋은 4월의 아침이다.",
+                    "emotion": "중립",
+                    "hashtag_1": "독서",
+                    "hashtag_2": "청소",
+                    "hashtag_3": "게임",
+                    "written_date": "2022-05-15"
+                  }
+                ],
+                "isSuccess": true,
+                "code": 200
+              }
+            }
+          },
+          "400":{
+            "description": "Bad Request (request body (emotion) 이 존재하지 않음)",
+            "schema": {
+              "example": {
+                "isSuccess": false,
+                "code": 400,
+                "message": "Check Emotion Input."
+              }
+            }
+          },
+          "404": {
+            "description": "Not Found (존재하지 않는 providerId에 대한 조회 요청)",
+            "schema": {
+              "example": {
+                "isSuccess": false,
+                "code": 404,
+                "message": "Check id value."
+              }
+            }
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "schema": {
+              "example": {
+                "isSuccess": false,
+                "code": 500,
+                "message": "Failed to get diary by emotion."
+              }
+            }
+          }
+        }
+      }
+    },
     "/diaries/hashtags/{id}": {
       "patch": {
         "tags": ["Diary"],
@@ -1094,7 +1185,7 @@
         }
       }
     },
-    "/diaries/emotioncounts/:providerId":{
+    "/diaries/emotioncounts/{providerId}":{
       "get" : {
         "tags" : ["Diary"],
         "summary" : "사용자별 감정별 일기 개수 Count - Frontend",

--- a/test/test.diary.js
+++ b/test/test.diary.js
@@ -10,6 +10,9 @@ let updateContent = { content: "너와 함께라면 나는 언제나 행복해" 
 let emotion = {
   emotion: "슬픔",
 };
+let emotion2 = {
+  emotion : "중립"
+};
 
 let hashtag = {
     hashtag_1 : "김밥",
@@ -529,6 +532,85 @@ describe("POST /diaries/searchresults/:providerId", () => {
       });
   });
 });
+
+describe("POST /diaries/emotions/:providerId", () => {
+  it("존재하지 않는 사용자의 감정별 일기목록을 가져오는 Test", (done) => {
+    request(app)
+      .post("/diaries/emotions/90614412523")
+      .send(emotion2)
+      .end((err, res) => {
+        if (err) {
+          throw err;
+        }
+        res.body.code.should.be.equal(404);
+        res.body.isSuccess.should.be.equal(false);
+        res.body.message.should.be.equal("Check id value.");
+        console.log(res.body);
+        done();
+      });
+  });
+});
+
+describe("POST /diaries/emotions/:providerId", () => {
+  it("사용자의 감정별 일기목록을 가져오는데 실패하는 Test(body 존재 x)", (done) => {
+    request(app)
+      .post("/diaries/emotions/906457842")
+      .end((err, res) => {
+        if (err) {
+          throw err;
+        }
+        res.body.code.should.be.equal(400);
+        res.body.isSuccess.should.be.equal(false);
+        res.body.message.should.be.equal("Check Emotion Input.");
+        console.log(res.body);
+        done();
+      });
+  });
+});
+
+describe("POST /diaries/emotions/:providerId", () => {
+  it("사용자의 감정별 일기목록을 가져오는데 실패하는 Test(잘못된 감정 입력)", (done) => {
+    request(app)
+      .post("/diaries/emotions/906457842")
+      .send({"emotion" : "죽음"})
+      .end((err, res) => {
+        if (err) {
+          throw err;
+        }
+        res.body.code.should.be.equal(400);
+        res.body.isSuccess.should.be.equal(false);
+        res.body.message.should.be.equal("Check Emotion Input.");
+        console.log(res.body);
+        done();
+      });
+  });
+});
+
+describe("POST /diaries/emotions/:providerId", () => {
+  it("사용자의 감정별 일기목록을 가져오는데 성공하는 Test", (done) => {
+    request(app)
+      .post("/diaries/emotions/906457842")
+      .send(emotion2)
+      .end((err, res) => {
+        if (err) {
+          throw err;
+        }
+        res.body.code.should.be.equal(200);
+        res.body.isSuccess.should.be.equal(true);
+        res.body.should.have.property("getDiaryResult");
+        should.exist(res.body.getDiaryResult[0].id);
+        should.exist(res.body.getDiaryResult[0].emotion);
+        should.exist(res.body.getDiaryResult[0].content);
+        should.exist(res.body.getDiaryResult[0].providerId);
+        should.exist(res.body.getDiaryResult[0].hashtag_1);
+        should.exist(res.body.getDiaryResult[0].hashtag_2);
+        should.exist(res.body.getDiaryResult[0].hashtag_3);
+        console.log(res.body);
+        done();
+      });
+  });
+});
+
 
 describe("POST /diaries/searchresults/:providerId", () => {
   it("존재하지 않는 값 검색 Test", (done) => {


### PR DESCRIPTION
## 제목
사용자 Id별 감정에 따른 일기 목록 제공하는 API 추가

## 작업 내용
diary API 에서 /diaries/emotions/:providerID에 해당하는 API 구현

## 설명 ( 필요 시 )
사용자 providerId 별 입력 감정에 따른 일기 목록 반환하는 API 구현

## 테스트 여부 / 테스트 방법

Mocha와 Supertest를 통한 테스트 완료

